### PR TITLE
detect_unused_locals.lua

### DIFF
--- a/src/luacheck/stages/detect_unused_locals.lua
+++ b/src/luacheck/stages/detect_unused_locals.lua
@@ -67,6 +67,10 @@ local type_codes = {
 }
 
 local function warn_unused_var(chstate, value, is_useless)
+   if value.var.type == "arg" and (value.var.name:sub(1, 1) == "_" or value.var.name == "parent" or value.var.name == "event") then
+      return
+   end
+
    chstate:warn_value("21" .. type_codes[value.var.type], value, {
       secondary = is_secondary(value) or nil,
       func = value.type == "func" or nil,

--- a/src/luacheck/stages/detect_wrongnames_locals.lua
+++ b/src/luacheck/stages/detect_wrongnames_locals.lua
@@ -14,8 +14,14 @@ stage.warnings = {
    ["356"] = {message_format = "mutating for loop variable {name!}", fields = {"name"}}
 }
 
+local upperA = 65
+local upperZ = 90
+local lowerA = 97
+local lowerZ = 122
+local underscore = 95
+
 local function detect_startcase_not_upper(chstate, value, code)
-    if value.var.name:byte(1) < 65 or value.var.name:byte(1) > 90 then
+    if value.var.name:byte(1) < upperA or value.var.name:byte(1) > upperZ then
       local warning = {}
       warning.case = "upper"
       chstate:warn_value(code, value, warning)
@@ -23,7 +29,15 @@ local function detect_startcase_not_upper(chstate, value, code)
 end
 
 local function detect_startcase_not_lower(chstate, value, code)
-    if value.var.name:byte(1) < 97 or value.var.name:byte(1) > 122 then
+    if value.var.name:byte(1) < lowerA or value.var.name:byte(1) > lowerZ then
+      local warning = {}
+      warning.case = "lower"
+      chstate:warn_value(code, value, warning)
+    end
+end
+
+local function detect_startcase_not_lower_arg(chstate, value, code)
+    if (value.var.name:byte(1) < lowerA or value.var.name:byte(1) > lowerZ) and value.var.name:byte(1) ~= underscore and value.var.name ~= "..." then
       local warning = {}
       warning.case = "lower"
       chstate:warn_value(code, value, warning)
@@ -53,7 +67,7 @@ local function detect_unused_local(chstate, var)
         if value.type == "var" then
           detect_startcase_not_lower(chstate, value, "703")
         elseif value.type == "arg" then
-          detect_startcase_not_lower(chstate, value, "702")
+          detect_startcase_not_lower_arg(chstate, value, "702")
         elseif value.type == "loop" then
           if is_variable_index(value) then
             detect_startcase_not_lower(chstate, value, "704")


### PR DESCRIPTION
 ignore function args which start with an _
 ignore function args named 'parent' or 'event'
detect_wrongnames_locals.lua
 don't flag function args which start with _ as not lowercase
 don't glag '...' function args as not lowercase
 some readability changes